### PR TITLE
remove legacy code

### DIFF
--- a/endpoints.go
+++ b/endpoints.go
@@ -209,6 +209,9 @@ func multiAddrEI(w http.ResponseWriter, r *http.Request,
 
 	var arr []string
 	arr = append(earr, iarr...)
+	if len(oarr) == 0 {
+		oarr = append(earr, iarr...)
+	}
 
 	x := make([]format.MultigetAddrReturn, len(arr))
 	currentBh, err := electrs.CurrentBlockHeight()

--- a/format/base.go
+++ b/format/base.go
@@ -9,12 +9,14 @@ type RequestFormat struct {
 	Addresses []string `json:"addresses"`
 }
 
+// EIHelper is the helper used for the nutxotxs endpoint
 type EIHelper struct {
 	ExternalAddresses []string `json:"External"`
 	InternalAddresses []string `json:"Internal"`
+	OwnedAddresses    []string `json:"Owned"`
 }
 
-// EIRequestFormat is the return format used for the nutoxs endpoint
+// EIRequestFormat is the return format used for the nutxotxs endpoint
 type EIRequestFormat map[string]EIHelper
 
 // Balance is a copy of the struct esplora returns for balances


### PR DESCRIPTION
some reverse changes for mainnet and testnet. Implications for mainnet: categorise should be live. Implications for testnet: faster endpoints. Former was not deployed on mainnet, latter was not deployed on testnet