### PR TITLE
add mutex to map assign + connect to your own node

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ sudo tar -xvf go1.15.4.linux-amd64.tar.gz
 sudo mv go /usr/bin/
 ```
 
-2. Update paths
+2. Update path
 
 ```
 export GOROOT=/usr/bin/go

--- a/README.md
+++ b/README.md
@@ -12,4 +12,14 @@ sudo tar -xvf go1.15.4.linux-amd64.tar.gz
 sudo mv go /usr/bin/
 ```
 
-2. `go install github.com/bithyve/bithyve-wrapper`
+2. Update paths
+
+```
+export GOROOT=/usr/bin/go
+export GOPATH=$HOME/go
+export PATH=$GOPATH/bin:$GOROOT/bin:$PATH
+```
+
+3. Download and install wrapper
+
+`go install github.com/bithyve/bithyve-wrapper`

--- a/README.md
+++ b/README.md
@@ -1,3 +1,15 @@
 # BitHyve Wrapper
 
-BitHyve wrapper is a server instance that wraps around [electrs](https://github.com/Blockstream/electrs) to provide some additional functionality on top of electrs as required by [hexa](https://github.com/bithyve/hexa).
+BitHyve wrapper is a server instance that wraps around [electrs](https://github.com/Blockstream/electrs) to provide some additional functionality on top of electrs as required by [hexa](https://github.com/bithyve/hexa)
+
+## Getting Started
+
+1. Install golang (replace 1.15.4 with your favorite version)
+
+```
+wget https://dl.google.com/go/go1.15.4.linux-amd64.tar.gz
+sudo tar -xvf go1.15.4.linux-amd64.tar.gz
+sudo mv go /usr/bin/
+```
+
+2. `go install github.com/bithyve/bithyve-wrapper`

--- a/endpoints.go
+++ b/endpoints.go
@@ -405,7 +405,8 @@ func NewMultiUtxoTxs() {
 			return
 		}
 
-		ret := make(format.EIUtxoReturn, len(rf))
+		var ret format.EIUtxoReturn
+		ret.Ret = make(format.EIUtxoReturnMap, len(rf))
 		var wg2 sync.WaitGroup
 		for key, elem := range rf {
 			wg2.Add(1)
@@ -443,11 +444,11 @@ func NewMultiUtxoTxs() {
 						temp.Utxos = append(temp.Utxos, elem)
 					}
 				}
-				ret[key] = temp
+				ret.Assign(key, temp)
 			}(&wg2, key, elem)
 		}
 		wg2.Wait()
-		erpc.MarshalSend(w, ret)
+		erpc.MarshalSend(w, ret.Ret)
 	})
 }
 

--- a/format/return.go
+++ b/format/return.go
@@ -1,13 +1,28 @@
 package format
 
+import "sync"
+
 // UtxoTxReturn is the return structure used in /utxotxs
 type UtxoTxReturn struct {
 	Utxos        [][]Utxo             `json:"Utxos"`
 	Transactions []MultigetAddrReturn `json:"Txs"`
 }
 
+// EIUtxoReturnMap is a map helper
+type EIUtxoReturnMap map[string]UtxoTxReturn
+
 // EIUtxoReturn is the reutrn structure used in /nutxotxs
-type EIUtxoReturn map[string]UtxoTxReturn
+type EIUtxoReturn struct {
+	Ret map[string]UtxoTxReturn
+	mu  sync.Mutex
+}
+
+// Assign assigns key:elem in a map and locks mutex
+func (a *EIUtxoReturn) Assign(key string, elem UtxoTxReturn) {
+	a.mu.Lock()
+	a.Ret[key] = elem
+	a.mu.Unlock()
+}
 
 // BalTxReturn is a struct used for the baltxs endpoint
 type BalTxReturn struct {

--- a/main.go
+++ b/main.go
@@ -15,10 +15,12 @@ import (
 )
 
 var opts struct {
-	DevEnv  bool `short:"d" description:"Start dev env"`
-	Mainnet bool `short:"m" description:"Connect to mainnet"`
-	Test    bool `short:"t" description:"Use for testing"`
-	Logs    bool `short:"l" description:"Testing logs"`
+	DevEnv     bool   `short:"d" description:"Start dev env"`
+	Mainnet    bool   `short:"m" description:"Connect to mainnet"`
+	ElectrsURL string `short:"u" description:"Connect to your own electrs instance"`
+	BackupURL  string `short:"b" description:"Connect to your own backup electrs instance"`
+	Test       bool   `short:"t" description:"Use for testing"`
+	Logs       bool   `short:"l" description:"Testing logs"`
 }
 
 func startHandlers() {
@@ -62,6 +64,18 @@ func main() {
 	if opts.DevEnv {
 		log.Println("starting in devenv mode")
 		electrs.SetDevEnv()
+	}
+
+	if opts.ElectrsURL != "" {
+		if opts.BackupURL != "" {
+			electrs.SetURL(opts.ElectrsURL, opts.BackupURL)
+		} else {
+			if opts.Mainnet {
+				electrs.SetURL(opts.ElectrsURL, "https://api.bithyve.com")
+			} else {
+				electrs.SetURL(opts.ElectrsURL, "https://test-wrapper.bithyve.com")
+			}
+		}
 	}
 
 	if opts.Test {

--- a/setup.sh
+++ b/setup.sh
@@ -5,8 +5,8 @@ sudo apt-get update
 sudo apt-get -y upgrade
 sudo apt-get install build-essential
 
-wget https://dl.google.com/go/go1.14.1.linux-amd64.tar.gz
-sudo tar -xvf go1.14.1.linux-amd64.tar.gz
+wget https://dl.google.com/go/go1.15.4.linux-amd64.tar.gz
+sudo tar -xvf go1.15.4.linux-amd64.tar.gz
 sudo mv go /usr/bin/
 
 export GOROOT=/usr/bin/go
@@ -34,6 +34,10 @@ sudo apt-get install libclang-dev
 sudo apt-get install clang
 sudo apt-get install librocksdb-sys # or librocksdb-dev
 cargo build
+
+# run as sudo
+ulimit -n 50000
+
 # screen -SL electrs cargo run --release --bin electrs -- -vvvv --daemon-dir /home/ubuntu/.bitcoin --daemon-rpc-addr 127.0.0.1:18332 --network testnet --cors 0.0.0.0/0
 sudo screen -SL indexer ./target/release/electrs -vvvv --daemon-dir /home/ubuntu/.bitcoin --daemon-rpc-addr 127.0.0.1:8332 --cors 0.0.0.0/0 --network mainnet --bulk-index-threads 4 --index-batch-size 1000 --tx-cache-size 1000000
 


### PR DESCRIPTION
if you send duplicate ids (say id1, id2, id3, id1), the current code will have a race condition because the map is used inside a goroutine (and the two threads having id1 will throw a concurrent map error). With the current fix and mutex, such a condition should be avoided.